### PR TITLE
Add Harvard's passwordless authentication

### DIFF
--- a/entries/h/harvard.edu.json
+++ b/entries/h/harvard.edu.json
@@ -1,0 +1,11 @@
+{
+  "Harvard University": {
+    "mfa": "allowed",
+    "passwordless": "allowed",
+    "documentation": "https://harvard.service-now.com/ithelp?id=kb_article&sys_id=7d56d80347875650b4aa0f6c416d4309",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}


### PR DESCRIPTION
As mentioned in 2factorauth/twofactorauth#8414, Harvard now supports security keys for MFA and passkeys as part of their transition to Okta.