### PR TITLE
Add the rest of the University of California system

### DIFF
--- a/entries/b/berkeley.edu.json
+++ b/entries/b/berkeley.edu.json
@@ -2,7 +2,6 @@
   "University of California, Berkeley": {
     "img": "berkeley.edu.png",
     "mfa": "allowed",
-    "passwordless": "allowed",
     "documentation": "https://calnetweb.berkeley.edu/calnet-2-step",
     "categories": "universities",
     "regions": [

--- a/entries/b/berkeley.edu.json
+++ b/entries/b/berkeley.edu.json
@@ -1,11 +1,12 @@
 {
   "University of California, Berkeley": {
-    "mfa": "allowed",
-    "documentation": "https://calnetweb.berkeley.edu/calnet-2-step",
     "img": "berkeley.edu.png",
+    "mfa": "allowed",
+    "passwordless": "allowed",
+    "documentation": "https://calnetweb.berkeley.edu/calnet-2-step",
+    "categories": "universities",
     "regions": [
       "us"
-    ],
-    "categories": "universities"
+    ]
   }
 }

--- a/entries/u/ucdavis.edu.json
+++ b/entries/u/ucdavis.edu.json
@@ -1,0 +1,11 @@
+{
+  "University of California, Davis": {
+    "mfa": "allowed",
+    "passwordless": "allowed",
+    "documentation": "https://movetoduo.ucdavis.edu",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}

--- a/entries/u/ucdavis.edu.json
+++ b/entries/u/ucdavis.edu.json
@@ -1,7 +1,6 @@
 {
   "University of California, Davis": {
     "mfa": "allowed",
-    "passwordless": "allowed",
     "documentation": "https://movetoduo.ucdavis.edu",
     "categories": "universities",
     "regions": [

--- a/entries/u/uci.edu.json
+++ b/entries/u/uci.edu.json
@@ -1,6 +1,6 @@
 {
   "University of California, Irvine": {
-    "passwordless": "allowed",
+    "mfa": "allowed",
     "documentation": "https://www.oit.uci.edu/services/accounts-passwords/duo/",
     "categories": "universities",
     "regions": [

--- a/entries/u/uci.edu.json
+++ b/entries/u/uci.edu.json
@@ -1,0 +1,10 @@
+{
+  "University of California, Irvine": {
+    "passwordless": "allowed",
+    "documentation": "https://www.oit.uci.edu/services/accounts-passwords/duo/",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}

--- a/entries/u/ucla.edu.json
+++ b/entries/u/ucla.edu.json
@@ -1,7 +1,6 @@
 {
   "University of California, Los Angeles": {
     "mfa": "allowed",
-    "passwordless": "allowed",
     "documentation": "https://dts.ucla.edu/products-services/security/multi-factor-authentication/activate-ucla-logon-mfa",
     "categories": "universities",
     "regions": [

--- a/entries/u/ucla.edu.json
+++ b/entries/u/ucla.edu.json
@@ -1,0 +1,11 @@
+{
+  "University of California, Los Angeles": {
+    "mfa": "allowed",
+    "passwordless": "allowed",
+    "documentation": "https://dts.ucla.edu/products-services/security/multi-factor-authentication/activate-ucla-logon-mfa",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}

--- a/entries/u/ucr.edu.json
+++ b/entries/u/ucr.edu.json
@@ -1,7 +1,6 @@
 {
   "University of California, Riverside": {
     "mfa": "allowed",
-    "passwordless": "allowed",
     "documentation": "https://its.ucr.edu/mfa",
     "categories": "universities",
     "regions": [

--- a/entries/u/ucr.edu.json
+++ b/entries/u/ucr.edu.json
@@ -1,0 +1,11 @@
+{
+  "University of California, Riverside": {
+    "mfa": "allowed",
+    "passwordless": "allowed",
+    "documentation": "https://its.ucr.edu/mfa",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}

--- a/entries/u/ucsb.edu.json
+++ b/entries/u/ucsb.edu.json
@@ -1,6 +1,6 @@
 {
   "University of California, Santa Barbara": {
-    "passwordless": "allowed",
+    "mfa": "allowed",
     "documentation": "https://it.ucsb.edu/mfa",
     "categories": "universities",
     "regions": [

--- a/entries/u/ucsb.edu.json
+++ b/entries/u/ucsb.edu.json
@@ -1,0 +1,10 @@
+{
+  "University of California, Santa Barbara": {
+    "passwordless": "allowed",
+    "documentation": "https://it.ucsb.edu/mfa",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}

--- a/entries/u/ucsc.edu.json
+++ b/entries/u/ucsc.edu.json
@@ -1,0 +1,10 @@
+{
+  "University of California, Santa Cruz": {
+    "passwordless": "allowed",
+    "documentation": "https://slughub.ucsc.edu/its?id=kb_article&sysparm_article=KB0021200",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}

--- a/entries/u/ucsc.edu.json
+++ b/entries/u/ucsc.edu.json
@@ -1,6 +1,6 @@
 {
   "University of California, Santa Cruz": {
-    "passwordless": "allowed",
+    "mfa": "allowed",
     "documentation": "https://slughub.ucsc.edu/its?id=kb_article&sysparm_article=KB0021200",
     "categories": "universities",
     "regions": [

--- a/entries/u/ucsd.edu.json
+++ b/entries/u/ucsd.edu.json
@@ -1,0 +1,10 @@
+{
+  "University of California, San Diego": {
+    "mfa": "allowed",
+    "documentation": "https://blink.ucsd.edu/technology/security/services/two-step-login/",
+    "categories": "universities",
+    "regions": [
+      "us"
+    ]
+  }
+}


### PR DESCRIPTION
Depends on 2factorauth/twofactorauth#8418

This PR adds the UCs that support FIDO2-based MFA or passkeys.

UC San Diego's support pages do not have any pages or screenshots which say "Touch ID" or "passkey". UCSF supports neither FIDO2 MFA nor passkeys.