### PR TITLE
Add passkeys support to AWS

### DIFF
--- a/entries/a/aws.amazon.com.json
+++ b/entries/a/aws.amazon.com.json
@@ -1,7 +1,9 @@
 {
   "Amazon Web Services": {
     "mfa": "allowed",
+    "passwordless": "allowed",
     "documentation": "https://aws.amazon.com/iam/features/mfa/",
+    "notes": "Passkeys are not supported in the China (Beijing) or China (Ningxia) regions.",
     "categories": [
       "cloud",
       "domains",


### PR DESCRIPTION
AWS added support for passkeys in June 2024. See [their blog post](https://aws.amazon.com/blogs/aws/aws-adds-passkey-multi-factor-authentication-mfa-for-root-and-iam-users/) and [what's new page](https://aws.amazon.com/about-aws/whats-new/2024/06/aws-identity-access-management-passkey-authentication-factor/).