### PR TITLE
fix: wait on each specific icon test PID

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,15 +57,8 @@ jobs:
       - name: Validate Icons
         if: ${{ steps.diff.outputs.entries || steps.diff.outputs.icons }}
         run: |
-          node tests/icons.js &
-          ICON_PID=$!
-
-          node tests/svg.js "${{ steps.diff.outputs.icons }}" &
-          SVG_PID=$!
-
-          wait "${ICON_PID}"
-
-          wait "${SVG_PID}"
+          node tests/icons.js
+          node tests/svg.js ${{ steps.diff.outputs.icons }}
 
       - name: Validate URL reachability
         if: steps.diff.outputs.entries


### PR DESCRIPTION
@hkamran80 per your note in #58, it looks like the icon tests are run in the background, but the single `wait` returns the last command's exit status (since it doesn't specify the PID to wait for).

With the changes in this PR, it should fail properly, regardless of which test fails.

I used this to test locally:
```bash
$ gh act -W .github/workflows/pull_request.yml --eventpath events.json --env GITHUB_REPOSITORY="2factorauth/passkeys"

$ cat events.json
{
  "number": "58",
  "pull_request": {
    "title": "test title"
  },
  "repository": {
    "name": "passkeys"
  }
}
```

Possibly as a result of the way the tests are currently set up, it appears there are quite a few (200+) missing icons, going by the output :sweat_smile:

I believe this should help fix that going forward.