### PR TITLE
Add Woolworths

### DIFF
--- a/entries/w/woolworths.com.au.json
+++ b/entries/w/woolworths.com.au.json
@@ -1,0 +1,9 @@
+{
+  "Woolworths": {
+    "passwordless": "allowed",
+    "categories": "retail",
+    "regions": [
+      "au"
+    ]
+  }
+}


### PR DESCRIPTION
Doco can be found here: https://www.woolworths.com.au/shop/help/account-security-privacy

No individual link to the Passkeys section sadly.