### PR TITLE
Add Chase, Capital One, Wells Fargo and Walmart

### DIFF
--- a/entries/c/capitalone.com.json
+++ b/entries/c/capitalone.com.json
@@ -1,0 +1,13 @@
+{
+  "Capital One": {
+    "additional-domains": [
+      "capitalone.co.uk"
+    ],
+    "passwordless": "allowed",
+    "documentation": "https://www.capitalone.com/help-center/sign-in-and-identity/passkeys/",
+    "regions": [
+      "us"
+    ],
+    "categories": "banking"
+  }
+}

--- a/entries/c/capitalone.com.json
+++ b/entries/c/capitalone.com.json
@@ -1,8 +1,5 @@
 {
   "Capital One": {
-    "additional-domains": [
-      "capitalone.co.uk"
-    ],
     "passwordless": "allowed",
     "documentation": "https://www.capitalone.com/help-center/credit-cards/passkey-support/",
     "regions": [

--- a/entries/c/capitalone.com.json
+++ b/entries/c/capitalone.com.json
@@ -4,7 +4,7 @@
       "capitalone.co.uk"
     ],
     "passwordless": "allowed",
-    "documentation": "https://www.capitalone.com/help-center/sign-in-and-identity/passkeys/",
+    "documentation": "https://www.capitalone.com/help-center/credit-cards/passkey-support/",
     "regions": [
       "us"
     ],

--- a/entries/c/chase.com.json
+++ b/entries/c/chase.com.json
@@ -1,8 +1,5 @@
 {
   "Chase": {
-    "additional-domains": [
-      "chase.co.uk"
-    ],
     "passwordless": "allowed",
     "documentation": "https://www.chase.com",
     "regions": [

--- a/entries/c/chase.com.json
+++ b/entries/c/chase.com.json
@@ -1,7 +1,8 @@
 {
   "Chase": {
     "passwordless": "allowed",
-    "documentation": "https://www.chase.com",
+    "documentation": "https://www.chase.com/digital/resources/privacy-security/security/how-you-can-protect",
+    "notes": "Passkeys only work on the web.",
     "regions": [
       "us"
     ],

--- a/entries/c/chase.com.json
+++ b/entries/c/chase.com.json
@@ -1,0 +1,13 @@
+{
+  "Chase": {
+    "additional-domains": [
+      "chase.co.uk"
+    ],
+    "passwordless": "allowed",
+    "documentation": "https://www.chase.com",
+    "regions": [
+      "us"
+    ],
+    "categories": "banking"
+  }
+}

--- a/entries/w/walmart.com.json
+++ b/entries/w/walmart.com.json
@@ -1,0 +1,10 @@
+{
+  "Walmart": {
+    "passwordless": "allowed",
+    "documentation": "https://www.walmart.com/help/article/passkeys/79bc4a57374146c497ebe3bf8d4f9b10",
+    "regions": [
+      "us"
+    ],
+    "categories": "retail"
+  }
+}

--- a/entries/w/wellsfargo.com.json
+++ b/entries/w/wellsfargo.com.json
@@ -1,0 +1,10 @@
+{
+  "Wells Fargo": {
+    "passwordless": "allowed",
+    "documentation": "https://www.wellsfargo.com/help/security-and-fraud/passkey-faqs/",
+    "regions": [
+      "us"
+    ],
+    "categories": "banking"
+  }
+}


### PR DESCRIPTION
These sites now support passwordless login in US.