### PR TITLE
Add US Bank: it now supports passkey based login: it supports passwordless login

### DIFF
--- a/entries/u/usbank.com.json
+++ b/entries/u/usbank.com.json
@@ -1,0 +1,10 @@
+{
+  "U.S. Bank": {
+    "passwordless": "allowed",
+    "documentation": "https://www.usbank.com/online-mobile-banking/passkey.html",
+    "regions": [
+      "us"
+    ],
+    "categories": "banking"
+  }
+}


### PR DESCRIPTION
Add US Bank: it now supports passkey based login: it supports passwordless login, though it requires a different 2FA.