### PR TITLE
Update Facebook

### DIFF
--- a/entries/f/facebook.com.json
+++ b/entries/f/facebook.com.json
@@ -1,10 +1,10 @@
 {
   "Facebook": {
-    "additional-domains": [
-      "messenger.com"
-    ],
+    "additional-domains": ["messenger.com"],
+    "passwordless": "allowed",
     "mfa": "allowed",
-    "documentation": "https://www.facebook.com/help/148233965247823",
+    "documentation": "https://www.facebook.com/help/1181045243159511",
+    "recovery": "https://www.facebook.com/help/147926301947841",
     "categories": "social"
   }
 }

--- a/entries/f/facebook.com.json
+++ b/entries/f/facebook.com.json
@@ -1,6 +1,8 @@
 {
   "Facebook": {
-    "additional-domains": ["messenger.com"],
+    "additional-domains": [
+      "messenger.com"
+    ],
     "passwordless": "allowed",
     "mfa": "allowed",
     "documentation": "https://www.facebook.com/help/1181045243159511",


### PR DESCRIPTION
Facebook supports both mfa passkeys (https://www.facebook.com/help/401566786855239) and passwordless passkeys